### PR TITLE
refactor: Tauri推奨のapp_data_dirを使用するように設定ファイル保存場所を変更

### DIFF
--- a/src-tauri/src/commands/profile.rs
+++ b/src-tauri/src/commands/profile.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use tauri::State;
+use tauri::{State, AppHandle};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use crate::profile::{ConnectionProfile, ProfileManager};
@@ -50,11 +50,12 @@ impl ProfileManagerState {
 pub async fn create_profile(
     request: CreateProfileRequest,
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<ConnectionProfile, String> {
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;
@@ -94,11 +95,12 @@ pub async fn create_profile(
 #[tauri::command]
 pub async fn list_profiles(
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<Vec<ConnectionProfile>, String> {
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;
@@ -113,11 +115,12 @@ pub async fn list_profiles(
 pub async fn get_profile(
     id: String,
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<ConnectionProfile, String> {
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;
@@ -132,11 +135,12 @@ pub async fn get_profile(
 pub async fn update_profile(
     request: UpdateProfileRequest,
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<ConnectionProfile, String> {
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;
@@ -167,11 +171,12 @@ pub async fn update_profile(
 pub async fn delete_profile(
     id: String,
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<(), String> {
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;
@@ -186,6 +191,7 @@ pub async fn delete_profile(
 pub async fn connect_with_profile(
     profile_id: String,
     state: State<'_, ProfileManagerState>,
+    app_handle: AppHandle,
 ) -> Result<String, String> {
     use crate::database::adapter::create_adapter;
     use crate::commands::{ADAPTER_STATE, CONNECTION_CANCEL_TOKEN};
@@ -194,7 +200,7 @@ pub async fn connect_with_profile(
     let mut manager_guard = state.0.lock().await;
 
     if manager_guard.is_none() {
-        *manager_guard = Some(ProfileManager::new().map_err(|e| e.to_string())?);
+        *manager_guard = Some(ProfileManager::new(&app_handle).map_err(|e| e.to_string())?);
     }
 
     let manager = manager_guard.as_ref().ok_or("Profile manager not initialized")?;

--- a/src-tauri/src/profile/mod.rs
+++ b/src-tauri/src/profile/mod.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use chrono::{DateTime, Utc};
+use tauri::AppHandle;
 use crate::database::adapter::{ConnectionParams, DatabaseType};
 use crate::error::AppError;
 
@@ -80,8 +81,8 @@ pub struct ProfileManager {
 
 impl ProfileManager {
     /// Create a new profile manager
-    pub fn new() -> Result<Self, AppError> {
-        let storage = storage::ProfileStorage::new()?;
+    pub fn new(app_handle: &AppHandle) -> Result<Self, AppError> {
+        let storage = storage::ProfileStorage::new(app_handle)?;
         Ok(Self { storage })
     }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   ChevronRight,
   ChevronDown,
@@ -55,12 +55,17 @@ interface ProjectGroup {
 }
 
 export function Sidebar({ isOpen, onToggle, onNewConnection, onEditConnection }: SidebarProps) {
-  const { profiles, deleteProfile } = useProfileStore();
+  const { profiles, deleteProfile, loadProfiles } = useProfileStore();
   const { connectWithProfile, currentProfile, disconnect, isConnecting } = useConnectionStore();
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set(['default']));
   const [expandedConnections, setExpandedConnections] = useState<Set<string>>(new Set());
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [deletingProfile, setDeletingProfile] = useState<ConnectionProfile | null>(null);
+
+  // 初期ロード時にプロファイルを読み込む
+  useEffect(() => {
+    loadProfiles();
+  }, [loadProfiles]);
 
   // プロジェクトごとにグループ化
   const groupedProfiles = profiles.reduce<Record<string, ConnectionProfile[]>>((groups, profile) => {


### PR DESCRIPTION
## 概要
設定ファイルの保存場所を、Tauriが推奨する`app_data_dir` APIを使用するように変更しました。

## 変更前後の比較

### 変更前
- `~/.dataforge/profiles/profiles.encrypted` に直接保存
- ホームディレクトリに隠しフォルダを作成する方法（非推奨）

### 変更後  
- **macOS**: `~/Library/Application Support/com.hnk.dataforge/profiles/profiles.encrypted`
- **Linux**: `~/.local/share/com.hnk.dataforge/profiles/profiles.encrypted`
- **Windows**: `%APPDATA%\com.hnk.dataforge\profiles\profiles.encrypted`

## 変更内容
- `ProfileStorage::new()` を `ProfileStorage::new(app_handle: &AppHandle)` に変更
- Tauriの`Manager`トレイトを使用して`app_handle.path().app_data_dir()`でパスを取得
- `ProfileManager`と全てのプロファイル関連コマンドに`AppHandle`を追加
- Sidebarコンポーネントで初期ロード時にプロファイルを読み込むように修正

## テスト結果
- ✅ プロファイルの作成・保存が正常に動作
- ✅ アプリケーションリロード後もプロファイルが表示される
- ✅ 保存したプロファイルでデータベースに接続できる
- ✅ 新しいディレクトリ構造が正しく作成される

## 参考資料
- [Tauri v2 File System Documentation](https://v2.tauri.app/plugin/file-system/)
- [Tauri Path API](https://v2.tauri.app/reference/javascript/api/namespacepath/)

この変更により、Tauriのベストプラクティスに準拠し、各OSの標準的な場所にアプリケーションデータが保存されるようになりました。

🤖 Generated with [Claude Code](https://claude.ai/code)